### PR TITLE
Soporte para datasets COCO de catarata y retinopatía

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ model = load_model("facebook/sam2-huge", qlora=True)
 
 Los parámetros `r`, `alpha` y `dropout` pueden ajustarse según las necesidades del entrenamiento.
 
+## Entrenamiento con datasets en formato COCO
+
+Los conjuntos de datos de cataratas y retinopatía diabética incluidos en `data/raw/`
+siguen el formato COCO. Para entrenar modelos de segmentación es posible utilizar
+los scripts de `src/training`:
+
+```bash
+python -m src.training.supervised --train "data/raw/Cataract COCO Segmentation/train" \
+    --val "data/raw/Cataract COCO Segmentation/valid"
+
+python -m src.training.semi_supervised_train --train \
+    "data/raw/Diabetic-Retinopathy COCO Segmentation/train"
+```
+
+Cada carpeta (`train`, `valid`) debe contener las imágenes y el archivo
+`_annotations.coco.json` correspondiente.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ torchvision>=0.17
 numpy
 pillow
 tqdm
+pycocotools
 peft
 bitsandbytes
 transformers

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,11 +1,12 @@
 """Data related utilities and datasets."""
 
-from .datasets import SkinPairDataset, UnlabeledDataset
+from .datasets import CocoSegDataset, SkinPairDataset, UnlabeledDataset
 from .augmentations import weak_transform, strong_transform
 
 __all__ = [
     "SkinPairDataset",
     "UnlabeledDataset",
+    "CocoSegDataset",
     "weak_transform",
     "strong_transform",
 ]

--- a/src/training/semi_supervised_train.py
+++ b/src/training/semi_supervised_train.py
@@ -3,128 +3,131 @@
 import argparse
 import itertools
 from pathlib import Path
+
 import torch
 import torch.nn.functional as F
 import tqdm
 
-from src.data import SkinPairDataset, UnlabeledDataset
+from src.data import CocoSegDataset, UnlabeledDataset
 from src.models import get_model
-from src.utils import (
-    dice_score,
-    find_pairs,
-    iou_score,
-    ssim_score,
-    update_ema,
-)
+from src.utils import dice_score, iou_score, ssim_score, update_ema
 
 
 def run(args: argparse.Namespace) -> None:
     # --- 1. Datos --------------------------------------------------------
-    img_dir = Path(args.images)
-    mask_dir = Path(args.masks)
-    valid_split = getattr(args, "valid_split", 0.2)
-    pairs = find_pairs(img_dir, mask_dir)
-    cut = int(len(pairs) * 0.8)
-    
-    labeled_pairs = pairs[:cut]
-    num_valid = int(len(labeled_pairs) * valid_split)
-    train_pairs = labeled_pairs[:-num_valid]
-    val_pairs = labeled_pairs[-num_valid:]
-    
-    l_train = SkinPairDataset(train_pairs)
-    l_val = SkinPairDataset(val_pairs)
-    
-    unlabeled_paths = [img_path for img_path, _ in pairs[cut:]]
+    data_dir = Path(args.train)
+    full_ds = CocoSegDataset(data_dir, data_dir / "_annotations.coco.json")
+    valid_split = args.valid_split
+
+    ids = full_ds.ids
+    cut = int(len(ids) * 0.8)
+    labeled_ids = ids[:cut]
+    unlabeled_ids = ids[cut:]
+
+    num_valid = int(len(labeled_ids) * valid_split)
+    train_ids = labeled_ids[:-num_valid]
+    val_ids = labeled_ids[-num_valid:]
+
+    l_train = CocoSegDataset(data_dir, data_dir / "_annotations.coco.json", ids=train_ids)
+    l_val = CocoSegDataset(data_dir, data_dir / "_annotations.coco.json", ids=val_ids)
+
+    unlabeled_paths = [
+        str(data_dir / full_ds.coco.loadImgs(i)[0]["file_name"]) for i in unlabeled_ids
+    ]
     u_train = UnlabeledDataset(unlabeled_paths)
 
     l_dl = torch.utils.data.DataLoader(l_train, batch_size=args.bs, shuffle=True)
     u_dl = torch.utils.data.DataLoader(u_train, batch_size=args.bs, shuffle=True)
     val_dl = torch.utils.data.DataLoader(l_val, batch_size=args.bs)
-    
+
     # --- 2. Modelos ------------------------------------------------------
     device = "cuda" if torch.cuda.is_available() else "cpu"
     student = get_model(args.model).to(device)
     teacher = get_model(args.model).to(device)
     teacher.load_state_dict(student.state_dict())
     teacher.eval()
-    
+
     opt = torch.optim.Adam(student.parameters(), lr=args.lr)
     bce = torch.nn.BCEWithLogitsLoss()
-    
+
     # --- 3. Entrenamiento -----------------------------------------------
     u_iter = iter(itertools.cycle(u_dl))
     for epoch in range(args.epochs):
         student.train()
         t_loss = t_dice = t_iou = t_ssim = 0.0
-        for weak_l, strong_l, mask_l in tqdm.tqdm(l_dl, desc=f"Ep {epoch+1}/{args.epochs}"):
-            weak_l, strong_l, mask_l = (x.to(device) for x in (weak_l, strong_l, mask_l))
-            
-            
-    # supervised loss
-    logit_sup = student(weak_l)
-    loss_sup = bce(logit_sup, mask_l)
-    
-    # unsupervised consistency
-    weak_u, strong_u = next(u_iter)
-    weak_u, strong_u = weak_u.to(device), strong_u.to(device)
-    
-    with torch.no_grad():
-        pseudo = torch.sigmoid(teacher(weak_u))
+        for weak_l, strong_l, mask_l in tqdm.tqdm(
+            l_dl, desc=f"Ep {epoch+1}/{args.epochs}"
+        ):
+            weak_l, strong_l, mask_l = (
+                x.to(device) for x in (weak_l, strong_l, mask_l)
+            )
 
-    conf_mask = (pseudo > args.tau).float()
-    if conf_mask.sum() > 0:
-        logit_u = student(strong_u)
-        loss_cons = F.binary_cross_entropy_with_logits(
-            logit_u, (pseudo > 0.5).float(), weight=conf_mask
-        )
-    else:
-        loss_cons = torch.tensor(0.0, device=device)
+            # supervised loss
+            logit_sup = student(weak_l)
+            loss_sup = bce(logit_sup, mask_l)
 
-    loss = loss_sup + args.lmbda * loss_cons
-    opt.zero_grad()
-    loss.backward()
-    opt.step()
+            # unsupervised consistency
+            weak_u, strong_u = next(u_iter)
+            weak_u, strong_u = weak_u.to(device), strong_u.to(device)
 
-    update_ema(student, teacher, alpha=args.ema)
+            with torch.no_grad():
+                pseudo = torch.sigmoid(teacher(weak_u))
 
-    t_loss += loss.item() * weak_l.size(0)
-    t_dice += dice_score(logit_sup, mask_l).item() * weak_l.size(0)
-    t_iou += iou_score(logit_sup, mask_l).item() * weak_l.size(0)
-    t_ssim += ssim_score(logit_sup, mask_l).item() * weak_l.size(0)
+            conf_mask = (pseudo > args.tau).float()
+            if conf_mask.sum() > 0:
+                logit_u = student(strong_u)
+                loss_cons = F.binary_cross_entropy_with_logits(
+                    logit_u, (pseudo > 0.5).float(), weight=conf_mask
+                )
+            else:
+                loss_cons = torch.tensor(0.0, device=device)
 
-    # --- 4. Validación ------------------------------------------------
-    student.eval()
-    v_dice = v_iou = v_ssim = 0.0
-    with torch.no_grad():
-        for weak, _, mask in val_dl:
-            weak, mask = weak.to(device), mask.to(device)
-            logits = student(weak)
-            v_dice += dice_score(logits, mask).item() * weak.size(0)
-            v_iou += iou_score(logits, mask).item() * weak.size(0)
-            v_ssim += ssim_score(logits, mask).item() * weak.size(0)
-    
-    v_dice /= len(l_val)
-    v_iou /= len(l_val)
-    v_ssim /= len(l_val)
+            loss = loss_sup + args.lmbda * loss_cons
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
 
-    print(
-        f"Epoch {epoch+1} | Train Dice {t_dice/len(l_train):.4f} "
+            update_ema(student, teacher, alpha=args.ema)
+
+            t_loss += loss.item() * weak_l.size(0)
+            t_dice += dice_score(logit_sup, mask_l).item() * weak_l.size(0)
+            t_iou += iou_score(logit_sup, mask_l).item() * weak_l.size(0)
+            t_ssim += ssim_score(logit_sup, mask_l).item() * weak_l.size(0)
+
+        # --- 4. Validación ------------------------------------------------
+        student.eval()
+        v_dice = v_iou = v_ssim = 0.0
+        with torch.no_grad():
+            for weak, _, mask in val_dl:
+                weak, mask = weak.to(device), mask.to(device)
+                logits = student(weak)
+                v_dice += dice_score(logits, mask).item() * weak.size(0)
+                v_iou += iou_score(logits, mask).item() * weak.size(0)
+                v_ssim += ssim_score(logits, mask).item() * weak.size(0)
+
+        v_dice /= len(l_val)
+        v_iou /= len(l_val)
+        v_ssim /= len(l_val)
+
+        print(
+            f"Epoch {epoch+1} | Train Dice {t_dice/len(l_train):.4f} "
             f"IoU {t_iou/len(l_train):.4f} SSIM {t_ssim/len(l_train):.4f} | "
             f"Val Dice {v_dice:.4f} IoU {v_iou:.4f} SSIM {v_ssim:.4f}"
-    )
+        )
 
-    torch.save(student.state_dict(), f"{args.model}_semi.pth")
+        torch.save(student.state_dict(), f"{args.model}_semi.pth")
+
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     p = argparse.ArgumentParser()
-    p.add_argument("--images", required=True)
-    p.add_argument("--masks", required=True)
+    p.add_argument("--train", required=True)
     p.add_argument("--bs", type=int, default=8)
     p.add_argument("--lr", type=float, default=1e-3)
     p.add_argument("--epochs", type=int, default=30)
     p.add_argument("--tau", type=float, default=0.7, help="umbral confianza")
     p.add_argument("--lmbda", type=float, default=1.0, help="peso consistencia")
     p.add_argument("--ema", type=float, default=0.99)
+    p.add_argument("--valid_split", type=float, default=0.2)
     p.add_argument(
         "--model",
         default="sam2",
@@ -132,3 +135,4 @@ if __name__ == "__main__":  # pragma: no cover - CLI entry
         help="modelo de segmentación",
     )
     run(p.parse_args())
+

--- a/src/training/supervised.py
+++ b/src/training/supervised.py
@@ -6,19 +6,17 @@ from pathlib import Path
 import torch
 import tqdm
 
-from src.data import SkinPairDataset
+from src.data import CocoSegDataset
 from src.models import get_model
-from src.utils import dice_score, iou_score, ssim_score, find_pairs
+from src.utils import dice_score, iou_score, ssim_score
 
 
 def run(args: argparse.Namespace) -> None:
-    img_dir = Path(args.images)
-    mask_dir = Path(args.masks)
+    train_dir = Path(args.train)
+    val_dir = Path(args.val)
 
-    pairs = find_pairs(img_dir, mask_dir)
-    split = int(len(pairs) * 0.8)
-    train_ds = SkinPairDataset(pairs[:split])
-    val_ds = SkinPairDataset(pairs[split:])
+    train_ds = CocoSegDataset(train_dir, train_dir / "_annotations.coco.json")
+    val_ds = CocoSegDataset(val_dir, val_dir / "_annotations.coco.json")
 
     train_dl = torch.utils.data.DataLoader(train_ds, batch_size=args.bs, shuffle=True)
     val_dl = torch.utils.data.DataLoader(val_ds, batch_size=args.bs)
@@ -72,8 +70,12 @@ def run(args: argparse.Namespace) -> None:
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     parser = argparse.ArgumentParser()
-    parser.add_argument("--images", required=True, help="carpeta con imágenes JPG")
-    parser.add_argument("--masks", required=True, help="carpeta con máscaras PNG")
+    parser.add_argument(
+        "--train", required=True, help="directorio de entrenamiento en formato COCO"
+    )
+    parser.add_argument(
+        "--val", required=True, help="directorio de validación en formato COCO"
+    )
     parser.add_argument("--bs", type=int, default=8)
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--epochs", type=int, default=20)


### PR DESCRIPTION
## Summary
- Añadido `CocoSegDataset` para generar máscaras a partir de anotaciones COCO.
- Actualizados los scripts de entrenamiento para usar directorios `train`/`valid` con `_annotations.coco.json`.
- Documentado uso de datasets de catarata y retinopatía y agregado `pycocotools` a dependencias.

## Testing
- `pip install pycocotools`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8640af91083209c7dfa9077dc5079