### PR TITLE
Add Colab notebook for Teacher-Student-Basics experiments

### DIFF
--- a/colab_experiments.ipynb
+++ b/colab_experiments.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {"id": "intro"},
+   "source": [
+    "# Teacher-Student-Basics en Colab\n",
+    "Este notebook muestra cómo ejecutar experimentos con el repositorio **Teacher-Student-Basics**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {"id": "setup"},
+   "outputs": [],
+   "source": [
+    "#@title Clonar el repositorio e instalar dependencias\n",
+    "REPO_URL = \"https://github.com/<your_user>/Teacher-Student-Basics.git\"  #@param {type:\"string\"}\n",
+    "BRANCH = \"main\"  #@param {type:\"string\"}\n",
+    "\n",
+    "!git clone --depth 1 -b $BRANCH $REPO_URL\n",
+    "%cd Teacher-Student-Basics\n",
+    "!pip install -r requirements.txt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {"id": "load_model"},
+   "outputs": [],
+   "source": [
+    "#@title Cargar SAM2 con LoRA o QLoRA\n",
+    "from src.models.sam_lora import load_model\n",
+    "USE_Q_LORA = False  #@param {type:\"boolean\"}\n",
+    "\n",
+    "model = load_model(\"facebook/sam2-huge\", qlora=USE_Q_LORA)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {"id": "training"},
+   "outputs": [],
+   "source": [
+    "#@title Entrenamiento supervisado de ejemplo\n",
+    "TRAIN_DIR = \"data/raw/Cataract COCO Segmentation/train\"  #@param {type:\"string\"}\n",
+    "VAL_DIR = \"data/raw/Cataract COCO Segmentation/valid\"  #@param {type:\"string\"}\n",
+    "\n",
+    "!python -m src.training.supervised --train \"$TRAIN_DIR\" --val \"$VAL_DIR\"\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "Teacher-Student-Basics-Experiments",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add `colab_experiments.ipynb` notebook to run repository experiments on Google Colab.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a869718da083209d7f7a9f35338417